### PR TITLE
Improve api sync performance

### DIFF
--- a/accentor/accentor.xcdatamodeld/accentor.xcdatamodel/contents
+++ b/accentor/accentor.xcdatamodeld/accentor.xcdatamodel/contents
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="21513" systemVersion="22A380" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="Album" representedClassName="Album" syncable="YES" codeGenerationType="class">
+        <attribute name="createdAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="edition" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="editionDescription" optional="YES" attributeType="String"/>
         <attribute name="fetchedAt" attributeType="Date" usesScalarValueType="NO"/>
@@ -13,6 +14,7 @@
         <attribute name="releaseDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="reviewComment" optional="YES" attributeType="String"/>
         <attribute name="title" attributeType="String"/>
+        <attribute name="updatedAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <relationship name="albumArtists" optional="YES" toMany="YES" deletionRule="Cascade" ordered="YES" destinationEntity="AlbumArtist" inverseName="album" inverseEntity="AlbumArtist"/>
         <relationship name="tracks" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="Track" inverseName="album" inverseEntity="Track"/>
         <uniquenessConstraints>
@@ -31,6 +33,7 @@
         <relationship name="artist" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Artist" inverseName="albumArtists" inverseEntity="Artist"/>
     </entity>
     <entity name="Artist" representedClassName="Artist" syncable="YES" codeGenerationType="class">
+        <attribute name="createdAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="fetchedAt" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="id" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="image" optional="YES" attributeType="String"/>
@@ -40,6 +43,7 @@
         <attribute name="imageType" optional="YES" attributeType="String"/>
         <attribute name="name" attributeType="String"/>
         <attribute name="normalizedName" attributeType="String"/>
+        <attribute name="updatedAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <relationship name="albumArtists" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="AlbumArtist" inverseName="artist" inverseEntity="AlbumArtist"/>
         <relationship name="trackArtists" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="TrackArtist" inverseName="artist" inverseEntity="TrackArtist"/>
         <uniquenessConstraints>
@@ -52,6 +56,7 @@
         <attribute name="albumId" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="bitrate" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="codecId" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="createdAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="fetchedAt" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="id" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="length" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
@@ -59,6 +64,7 @@
         <attribute name="normalizedTitle" attributeType="String"/>
         <attribute name="number" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="title" attributeType="String"/>
+        <attribute name="updatedAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <relationship name="album" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Album" inverseName="tracks" inverseEntity="Album"/>
         <relationship name="trackArtists" optional="YES" toMany="YES" deletionRule="Cascade" ordered="YES" destinationEntity="TrackArtist" inverseName="track" inverseEntity="TrackArtist"/>
         <fetchIndex name="byAlbumId">


### PR DESCRIPTION
This PR improves the performance of our api sync by:
* Storing the timestamps from the server
* Only updating the other attributes if the `updatedAt` timestamp changed