### PR TITLE
Make the `PlayerViewModel` a singleton class

### DIFF
--- a/accentor/View/Player/Player.swift
+++ b/accentor/View/Player/Player.swift
@@ -12,7 +12,7 @@ import CachedAsyncImage
 struct Player: View {
     @State private var showQueue = false
 //    @FetchRequest(entity: QueueItem.entity(), sortDescriptors: [NSSortDescriptor(keyPath: \QueueItem.index, ascending: true)]) var queueItems : FetchedResults<QueueItem>
-    @StateObject var viewModel = PlayerViewModel()
+    @StateObject var viewModel = PlayerViewModel.shared
     @StateObject var playQueue = PlayQueue.shared
     
     func toggleShowQueue() {

--- a/accentor/View/Player/PlayerViewModel.swift
+++ b/accentor/View/Player/PlayerViewModel.swift
@@ -23,6 +23,10 @@ class PlayerViewModel: NSObject, ObservableObject {
     var canGoPrev: Bool {
         get { return playQueue.currentIndex > 0 }
     }
+    
+    // The PlayerViewModel is a singleton class, since we only want one player
+    // Otherwise our track would restart when the view was updated
+    public static let shared = PlayerViewModel()
 
     private var player: AVPlayer = AVPlayer()
     private var cancellables: Set<AnyCancellable> = []


### PR DESCRIPTION
Otherwise the playing track would restart when the view changes

Fixes #20 
