### PR TITLE
Don't recreate associations inside app

### DIFF
--- a/accentor.xcodeproj/project.pbxproj
+++ b/accentor.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		FD0C5CBD29644E50000AF7D6 /* README.md in Resources */ = {isa = PBXBuildFile; fileRef = FD0C5CB929644E50000AF7D6 /* README.md */; };
 		FD0C5CBE29644E50000AF7D6 /* LICENSE in Resources */ = {isa = PBXBuildFile; fileRef = FD0C5CBA29644E50000AF7D6 /* LICENSE */; };
 		FD89028B29BC873300AF8007 /* Album+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD89028A29BC873300AF8007 /* Album+CoreDataClass.swift */; };
+		FD89028D29BC968D00AF8007 /* Artist+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD89028C29BC968D00AF8007 /* Artist+CoreDataClass.swift */; };
 		FD8CAECE2965B98300BADDC4 /* CachedAsyncImage in Frameworks */ = {isa = PBXBuildFile; productRef = FD8CAECD2965B98300BADDC4 /* CachedAsyncImage */; };
 		FD8CAED12965B9C300BADDC4 /* AlbumImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD8CAED02965B9C300BADDC4 /* AlbumImage.swift */; };
 		FD8CAED32965BBD800BADDC4 /* ArtistImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD8CAED22965BBD800BADDC4 /* ArtistImage.swift */; };
@@ -74,6 +75,7 @@
 		FD0C5CB929644E50000AF7D6 /* README.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		FD0C5CBA29644E50000AF7D6 /* LICENSE */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = LICENSE; sourceTree = "<group>"; };
 		FD89028A29BC873300AF8007 /* Album+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Album+CoreDataClass.swift"; sourceTree = "<group>"; };
+		FD89028C29BC968D00AF8007 /* Artist+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Artist+CoreDataClass.swift"; sourceTree = "<group>"; };
 		FD8CAED02965B9C300BADDC4 /* AlbumImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlbumImage.swift; sourceTree = "<group>"; };
 		FD8CAED22965BBD800BADDC4 /* ArtistImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArtistImage.swift; sourceTree = "<group>"; };
 		FDCC753A29646CCD0079B983 /* PlayQueue.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PlayQueue.swift; sourceTree = "<group>"; };
@@ -156,6 +158,7 @@
 			isa = PBXGroup;
 			children = (
 				FD89028A29BC873300AF8007 /* Album+CoreDataClass.swift */,
+				FD89028C29BC968D00AF8007 /* Artist+CoreDataClass.swift */,
 				FDD37F46297DD75400967E55 /* Track+CoreDataClass.swift */,
 				FDCC753A29646CCD0079B983 /* PlayQueue.swift */,
 				FDCC753B29646CCD0079B983 /* PlayQueueItem.swift */,
@@ -482,6 +485,7 @@
 				FDCC756229646D200079B983 /* PlayService.swift in Sources */,
 				FD89028B29BC873300AF8007 /* Album+CoreDataClass.swift in Sources */,
 				FDCC75B629646D320079B983 /* LoginViewModel.swift in Sources */,
+				FD89028D29BC968D00AF8007 /* Artist+CoreDataClass.swift in Sources */,
 				FDCC75C529646D320079B983 /* CachingPlayerItem.swift in Sources */,
 				FDCC75B329646D320079B983 /* ArtistCard.swift in Sources */,
 				FDCC75A429646D320079B983 /* DefaultSettings.swift in Sources */,

--- a/accentor/Api/AlbumService.swift
+++ b/accentor/Api/AlbumService.swift
@@ -83,12 +83,6 @@ struct AlbumService {
                     nestedEntity.normalizedName = albumArtist.normalizedName
                     nestedEntity.order = albumArtist.order
                     nestedEntity.separator = albumArtist.separator
-
-                    // Look for the artist and re-create the association
-                    let fetchArtist: NSFetchRequest<Artist> = Artist.fetchRequest()
-                    fetchArtist.predicate = NSPredicate(format: "id == %ld", albumArtist.artistId)
-                    let artist = try? context.fetch(fetchArtist).first
-                    nestedEntity.artist = artist
                 }
             }
         }

--- a/accentor/Api/TrackService.swift
+++ b/accentor/Api/TrackService.swift
@@ -78,12 +78,6 @@ struct TrackService {
 
                 entity.albumId = track.albumId
                 
-                // Look for the album and re-create the association
-                let fetchAlbum: NSFetchRequest<Album> = Album.fetchRequest()
-                fetchAlbum.predicate = NSPredicate(format: "id == %ld", track.albumId)
-                let album = try? context.fetch(fetchAlbum).first
-                entity.album = album
-                
                 entity.trackArtists?.forEach({ item in
                     let trackArtist = item as! TrackArtist
                     context.delete(trackArtist)
@@ -99,12 +93,6 @@ struct TrackService {
                         nestedEntity.order = trackArtist.order
                         nestedEntity.role = trackArtist.role
                         nestedEntity.hidden = trackArtist.hidden
-
-                        // Look for the artist and re-create the association
-                        let fetchArtist: NSFetchRequest<Artist> = Artist.fetchRequest()
-                        fetchArtist.predicate = NSPredicate(format: "id == %ld", trackArtist.artistId)
-                        let artist = try? context.fetch(fetchArtist).first
-                        nestedEntity.artist = artist
                     }
 
                 }

--- a/accentor/Model/Album+CoreDataClass.swift
+++ b/accentor/Model/Album+CoreDataClass.swift
@@ -24,4 +24,13 @@ public class Album: NSManagedObject {
 
         }
     }
+    
+    var tracks: [Track] {
+        get {
+            let fetchRequest: NSFetchRequest<Track> = Track.fetchRequest()
+            fetchRequest.sortDescriptors = [NSSortDescriptor(keyPath: \Track.number, ascending: true)]
+            fetchRequest.predicate = NSPredicate(format: "albumId == %i", self.id)
+            return try! PersistenceController.shared.container.viewContext.fetch(fetchRequest)
+        }
+    }
 }

--- a/accentor/Model/Artist+CoreDataClass.swift
+++ b/accentor/Model/Artist+CoreDataClass.swift
@@ -1,0 +1,50 @@
+//
+//  Artist+CoreDataClass.swift
+//  accentor
+//
+//  Created by Robbe Van Petegem on 11/03/2023.
+//
+
+import Foundation
+import CoreData
+
+@objc(Artist)
+public class Artist: NSManagedObject {
+    var albums: [Album] {
+        get {
+            self.albumArtists.map({ item in return item.album! }).sorted { a1, a2 in
+                guard let r1 = a1.releaseDate else { return true }
+                guard let r2 = a2.releaseDate else { return false }
+                
+                return r1 < r2
+            }
+        }
+    }
+    
+    var albumArtists: [AlbumArtist] {
+        get {
+            let fetchRequest: NSFetchRequest<AlbumArtist> = AlbumArtist.fetchRequest()
+            fetchRequest.predicate = NSPredicate(format: "artistId == %i", self.id)
+            return try! PersistenceController.shared.container.viewContext.fetch(fetchRequest)
+        }
+    }
+    
+    var tracks: [Track] {
+        get {
+            self.trackArtists.map({ item in item.track! }).sorted { t1, t2 in
+                guard let title1 = t1.normalizedTitle else { return false }
+                guard let title2 = t2.normalizedTitle else { return true }
+                
+                return title1 < title2
+            }
+        }
+    }
+    
+    var trackArtists: [TrackArtist] {
+        get {
+            let fetchRequest: NSFetchRequest<TrackArtist> = TrackArtist.fetchRequest()
+            fetchRequest.predicate = NSPredicate(format: "artistId == %i", self.id)
+            return try! PersistenceController.shared.container.viewContext.fetch(fetchRequest)
+        }
+    }
+}

--- a/accentor/Model/PlayQueue.swift
+++ b/accentor/Model/PlayQueue.swift
@@ -51,25 +51,16 @@ class PlayQueue: ObservableObject {
     
     func addAlbumToQueue(album: Album, position: QueueItemPosition = .last, replace: Bool = false) {
         if replace { self.clearQueue() }
-    
-        let fetchRequest: NSFetchRequest<Track> = Track.fetchRequest()
-        fetchRequest.sortDescriptors = [NSSortDescriptor(keyPath: \Track.number, ascending: true)]
-        fetchRequest.predicate = NSPredicate(format: "albumId == %i", album.id)
         
-        do {
-            let tracks = try PersistenceController.shared.container.viewContext.fetch(fetchRequest)
-            let mapped = tracks.map { PlayQueueItem(track: $0) }
-            
-            switch position {
-            case .last: queue.insert(contentsOf: mapped, at: queue.endIndex)
-            case .next: queue.insert(contentsOf: mapped, at: min(queue.endIndex, 1))
-            }
-            
-            // Start playing if the queue was empty
-            if (queue.count == tracks.count) { setIndex(0) }
-        } catch let error {
-            print("Error fetching tracks \(error)")
+        let mapped = album.tracks.map { PlayQueueItem(track: $0) }
+        
+        switch position {
+        case .last: queue.insert(contentsOf: mapped, at: queue.endIndex)
+        case .next: queue.insert(contentsOf: mapped, at: min(queue.endIndex, 1))
         }
+        
+        // Start playing if the queue was empty
+        if (queue.count == album.tracks.count) { setIndex(0) }
         
     }
     

--- a/accentor/Model/Track+CoreDataClass.swift
+++ b/accentor/Model/Track+CoreDataClass.swift
@@ -11,6 +11,13 @@ import CoreData
 
 @objc(Track)
 public class Track: NSManagedObject {
+    var album: Album? {
+        get {
+            let fetchRequest: NSFetchRequest<Album> = Album.fetchRequest()
+            fetchRequest.predicate = NSPredicate(format: "id == %i", self.albumId)
+            return try! PersistenceController.shared.container.viewContext.fetch(fetchRequest).first ?? nil
+        }
+    }
     var trackArtistsText: String {
         get {
             guard let trackArtists = self.trackArtists else { return "" }

--- a/accentor/View/Artists/ArtistView.swift
+++ b/accentor/View/Artists/ArtistView.swift
@@ -9,24 +9,6 @@ import SwiftUI
 
 struct ArtistView: View {
     var artist: Artist
-    var albums: [Album] = []
-    var tracks: [Track] = []
-    
-    init(artist: Artist) {
-        self.artist = artist
-        if let albumArtists = artist.albumArtists {
-            self.albums = albumArtists.map({ item in
-                let aa = item as! AlbumArtist
-                return aa.album!
-            })
-        }
-        if let trackArtists = artist.trackArtists {
-            self.tracks = trackArtists.map({ item in
-                let ta = item as! TrackArtist
-                return ta.track!
-            })
-        }
-    }
 
     var body: some View {
         ScrollView {
@@ -40,13 +22,13 @@ struct ArtistView: View {
                 Text("Albums")
                 ScrollView(.horizontal) {
                     LazyHStack(spacing: 5) {
-                        ForEach(albums) { item in
+                        ForEach(artist.albums) { item in
                             AlbumCard(album: item).frame(minWidth: 130, maxWidth: 200)
                         }
                     }
                 }
                 Text("Tracks")
-                ForEach(tracks) { track in
+                ForEach(artist.tracks) { track in
                     Text(track.title ?? "")
                 }
             }

--- a/accentor/accentor.xcdatamodeld/accentor.xcdatamodel/contents
+++ b/accentor/accentor.xcdatamodeld/accentor.xcdatamodel/contents
@@ -30,7 +30,7 @@
         <attribute name="separator" optional="YES" attributeType="String"/>
         <relationship name="album" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Album" inverseName="albumArtists" inverseEntity="Album"/>
     </entity>
-    <entity name="Artist" representedClassName="Artist" syncable="YES" codeGenerationType="class">
+    <entity name="Artist" representedClassName="Artist" syncable="YES" codeGenerationType="category">
         <attribute name="createdAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="fetchedAt" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="id" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>

--- a/accentor/accentor.xcdatamodeld/accentor.xcdatamodel/contents
+++ b/accentor/accentor.xcdatamodeld/accentor.xcdatamodel/contents
@@ -16,7 +16,6 @@
         <attribute name="title" attributeType="String"/>
         <attribute name="updatedAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <relationship name="albumArtists" optional="YES" toMany="YES" deletionRule="Cascade" ordered="YES" destinationEntity="AlbumArtist" inverseName="album" inverseEntity="AlbumArtist"/>
-        <relationship name="tracks" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="Track" inverseName="album" inverseEntity="Track"/>
         <uniquenessConstraints>
             <uniquenessConstraint>
                 <constraint value="id"/>
@@ -30,7 +29,6 @@
         <attribute name="order" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="separator" optional="YES" attributeType="String"/>
         <relationship name="album" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Album" inverseName="albumArtists" inverseEntity="Album"/>
-        <relationship name="artist" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Artist" inverseName="albumArtists" inverseEntity="Artist"/>
     </entity>
     <entity name="Artist" representedClassName="Artist" syncable="YES" codeGenerationType="class">
         <attribute name="createdAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
@@ -44,8 +42,6 @@
         <attribute name="name" attributeType="String"/>
         <attribute name="normalizedName" attributeType="String"/>
         <attribute name="updatedAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
-        <relationship name="albumArtists" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="AlbumArtist" inverseName="artist" inverseEntity="AlbumArtist"/>
-        <relationship name="trackArtists" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="TrackArtist" inverseName="artist" inverseEntity="TrackArtist"/>
         <uniquenessConstraints>
             <uniquenessConstraint>
                 <constraint value="id"/>
@@ -65,7 +61,6 @@
         <attribute name="number" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="title" attributeType="String"/>
         <attribute name="updatedAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
-        <relationship name="album" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Album" inverseName="tracks" inverseEntity="Album"/>
         <relationship name="trackArtists" optional="YES" toMany="YES" deletionRule="Cascade" ordered="YES" destinationEntity="TrackArtist" inverseName="track" inverseEntity="TrackArtist"/>
         <fetchIndex name="byAlbumId">
             <fetchIndexElement property="albumId" type="Binary" order="ascending"/>
@@ -83,7 +78,6 @@
         <attribute name="normalizedName" attributeType="String"/>
         <attribute name="order" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
         <attribute name="role" attributeType="String"/>
-        <relationship name="artist" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Artist" inverseName="trackArtists" inverseEntity="Artist"/>
         <relationship name="track" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Track" inverseName="trackArtists" inverseEntity="Track"/>
     </entity>
 </model>


### PR DESCRIPTION
This PR removes the associations that got recreated when we were fetching albums, artists and tracks.

Instead of recreating the associations, we will use fetchRequests to get this data when the view or viewmodels require it.