### PR TITLE
Add now playing notification

### DIFF
--- a/accentor/View/Player/PlayerViewModel.swift
+++ b/accentor/View/Player/PlayerViewModel.swift
@@ -118,9 +118,7 @@ class PlayerViewModel: NSObject, ObservableObject {
             #if os(iOS)
             // Configure and activate the AVAudioSession
             // This is only available on iOS
-            try AVAudioSession.sharedInstance().setCategory(
-                AVAudioSession.Category.playback
-            )
+            try AVAudioSession.sharedInstance().setCategory(.playback)
 
             try AVAudioSession.sharedInstance().setActive(true)
             #endif


### PR DESCRIPTION
This PR adds support for `MPNowPlayingInfoCenter` and `MPRemoteCommandCenter` to out `PlayerViewModel`

We currently report basic info about our track and allow the commands that were already present in the player.
