### PR TITLE
Make sure we don't create additional `.empty()` player instances

### DIFF
--- a/accentor/accentorApp.swift
+++ b/accentor/accentorApp.swift
@@ -14,7 +14,7 @@ struct accentorApp: App {
     var body: some Scene {
         WindowGroup {
             if (userId != nil) {
-                AppWrapperView().environment(\.appDatabase, .shared).environment(\.player, .shared)
+                AppWrapperView()
             } else {
                 LoginView()
             }
@@ -36,6 +36,7 @@ struct accentorApp: App {
                 })
             }
         }
+        .environment(\.appDatabase, .shared).environment(\.player, .shared)
     }
 }
 


### PR DESCRIPTION
We were currently creating some additional `Player.empty()` instances (fe. when moving the screen in and out of focus). By moving the `.environment()` method up, we somehow don't 