### PR TITLE
Ensure `onThisDay` only selects albums where date and month match

### DIFF
--- a/accentor/View/Home/HomeViewModel.swift
+++ b/accentor/View/Home/HomeViewModel.swift
@@ -99,7 +99,7 @@ final class HomeViewModel: ObservableObject {
     
     private func fetchOnThisDay() {
         let df = DateFormatter()
-        df.dateFormat = "MM-dd"
+        df.dateFormat = "-MM-dd"
         ValueObservation
             .tracking(Album.filter(Column("release").like("%\(df.string(from: Date()))%")).order(Column("release").desc).fetchAll)
             .publisher(in: database.reader, scheduling: .async(onQueue: DispatchQueue.main))


### PR DESCRIPTION
Before this change, we could encounter edge cases where we would match YY-MM instead of MM-dd

Fixes #66 
