### PR TITLE
Make sure number has the same width, regardless of value.

### DIFF
--- a/accentor/View/TrackRow/TrackRowView.swift
+++ b/accentor/View/TrackRow/TrackRowView.swift
@@ -22,7 +22,7 @@ struct TrackRowView: View {
     var body: some View {
         HStack {
             if (showNumber) {
-                Text(String(viewModel.track.number)).padding(.trailing, 20)
+                Text(String(viewModel.track.number)).frame(width: 25, alignment: .leading)
             }
             VStack(alignment: .leading) {
                 Text(viewModel.track.title).foregroundStyle(Color.black)


### PR DESCRIPTION
Before this change, the width would change depending on the number of digits. Note that this layout will work for any number until 999. Albums with a 1000+ tracks might give issues
