### PR TITLE
Switch to new system with apiTokens

### DIFF
--- a/accentor/Api/AbstractService.swift
+++ b/accentor/Api/AbstractService.swift
@@ -50,8 +50,7 @@ class AbstractService {
                 ]
                 
                 var request = URLRequest(url: components.url!)
-                request.addValue(UserDefaults.standard.string(forKey: "deviceId")!, forHTTPHeaderField: "x-device-id")
-                request.addValue(UserDefaults.standard.string(forKey: "secret")!, forHTTPHeaderField: "x-secret")
+                request.addValue("Bearer \(UserDefaults.standard.string(forKey: "apiToken")!)", forHTTPHeaderField: "Authorization")
                 request.setValue(AbstractService.userAgent, forHTTPHeaderField: "user-agent")
                 
                 let session = URLSession(configuration: .default)
@@ -86,11 +85,8 @@ class AbstractService {
         var request = URLRequest(url: components.url!)
         request.httpMethod = "POST"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        if let deviceId = UserDefaults.standard.string(forKey: "deviceId") {
-            request.addValue(deviceId, forHTTPHeaderField: "x-device-id")
-        }
-        if let secret = UserDefaults.standard.string(forKey: "secret") {
-            request.addValue(secret, forHTTPHeaderField: "x-secret")
+        if let apiToken = UserDefaults.standard.string(forKey: "apiToken") {
+            request.addValue("Bearer \(apiToken)", forHTTPHeaderField: "Authorization")
         }
         request.setValue(AbstractService.userAgent, forHTTPHeaderField: "user-agent")
         

--- a/accentor/Api/AudioService.swift
+++ b/accentor/Api/AudioService.swift
@@ -63,8 +63,7 @@ class AudioService {
         
         components.queryItems = [
             URLQueryItem(name: "codec_conversion_id", value: UserDefaults.standard.string(forKey: "codecConversionId")!),
-            URLQueryItem(name: "secret", value: UserDefaults.standard.string(forKey: "secret")!),
-            URLQueryItem(name: "device_id", value: UserDefaults.standard.string(forKey: "deviceId")!)
+            URLQueryItem(name: "token", value: UserDefaults.standard.string(forKey: "apiToken")!)
         ]
         
         return components.url!

--- a/accentor/Api/AuthService.swift
+++ b/accentor/Api/AuthService.swift
@@ -15,8 +15,7 @@ struct APILoginBody: Codable {
 
 struct APILoginResponse: Decodable {
     let userId: Int64
-    let deviceId: String
-    let secret: String
+    let token: String
 }
 
 struct AuthService {
@@ -36,14 +35,12 @@ struct AuthService {
 
         let data = try AbstractService.jsonDecoder.decode(APILoginResponse.self, from: response)
         
-        UserDefaults.standard.set(data.deviceId, forKey: "deviceId")
-        UserDefaults.standard.set(data.secret, forKey: "secret")
+        UserDefaults.standard.set(data.token, forKey: "apiToken")
         UserDefaults.standard.set(data.userId, forKey: "userId")
     }
     
     func logout() async throws {
-        UserDefaults.standard.removeObject(forKey: "devicedId")
-        UserDefaults.standard.removeObject(forKey: "secret")
+        UserDefaults.standard.removeObject(forKey: "apiToken")
         UserDefaults.standard.removeObject(forKey: "userId")
         
         do {

--- a/accentor/Model/PlayQueueItem.swift
+++ b/accentor/Model/PlayQueueItem.swift
@@ -46,8 +46,7 @@ class PlayQueueItem {
         
         components.queryItems = [
             URLQueryItem(name: "codec_conversion_id", value: UserDefaults.standard.string(forKey: "codecConversionId")!),
-            URLQueryItem(name: "secret", value: UserDefaults.standard.string(forKey: "secret")!),
-            URLQueryItem(name: "device_id", value: UserDefaults.standard.string(forKey: "deviceId")!)
+            URLQueryItem(name: "token", value: UserDefaults.standard.string(forKey: "apiToken")!)
         ]
         
         return components.url!


### PR DESCRIPTION
re accentor/api#721

This switches our authentication method to use the new api tokens instead of device_id + secret. 