### PR TITLE
Switch to logging using OSLog

### DIFF
--- a/accentor.xcodeproj/project.pbxproj
+++ b/accentor.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		FD405A822B5877B6008A3CB3 /* ArtistViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD405A812B5877B6008A3CB3 /* ArtistViewModel.swift */; };
 		FD69881F2B61A36C0061FC90 /* AlbumView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD69881E2B61A36C0061FC90 /* AlbumView.swift */; };
 		FD6988212B61A3750061FC90 /* AlbumViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD6988202B61A3750061FC90 /* AlbumViewModel.swift */; };
+		FD76FEB22E3F8F0400C742DB /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD76FEB12E3F8F0100C742DB /* Logger.swift */; };
 		FD9074F32B716E78001676C0 /* View.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD9074F22B716E78001676C0 /* View.swift */; };
 		FDBE6BE72B559B20004F39CA /* appDatabase.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDBE6BE62B559B20004F39CA /* appDatabase.swift */; };
 		FDBE6BEA2B559B6C004F39CA /* GRDB in Frameworks */ = {isa = PBXBuildFile; productRef = FDBE6BE92B559B6C004F39CA /* GRDB */; };
@@ -105,6 +106,7 @@
 		FD405A812B5877B6008A3CB3 /* ArtistViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArtistViewModel.swift; sourceTree = "<group>"; };
 		FD69881E2B61A36C0061FC90 /* AlbumView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlbumView.swift; sourceTree = "<group>"; };
 		FD6988202B61A3750061FC90 /* AlbumViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlbumViewModel.swift; sourceTree = "<group>"; };
+		FD76FEB12E3F8F0100C742DB /* Logger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Logger.swift; sourceTree = "<group>"; };
 		FD9074F22B716E78001676C0 /* View.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = View.swift; sourceTree = "<group>"; };
 		FDBE6BE62B559B20004F39CA /* appDatabase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = appDatabase.swift; sourceTree = "<group>"; };
 		FDBE6BEB2B55B8B5004F39CA /* Album.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Album.swift; sourceTree = "<group>"; };
@@ -364,6 +366,7 @@
 				FDFFD6E729113CDE003A1501 /* accentorApp.swift */,
 				FDFFD6E929113CDE003A1501 /* Persistence.swift */,
 				FD9074F22B716E78001676C0 /* View.swift */,
+				FD76FEB12E3F8F0100C742DB /* Logger.swift */,
 				FDD00CF82B56CDDD007554F7 /* Player.swift */,
 				FDBE6BE62B559B20004F39CA /* appDatabase.swift */,
 				FDFFD6F029113CDF003A1501 /* Assets.xcassets */,
@@ -590,6 +593,7 @@
 				FDE5E6A02B6D7606006F1853 /* TrackRowView.swift in Sources */,
 				FDCC756829646D200079B983 /* ArtistService.swift in Sources */,
 				FDD00CFB2B56DDC8007554F7 /* PlayerView.swift in Sources */,
+				FD76FEB22E3F8F0400C742DB /* Logger.swift in Sources */,
 				FDCC756529646D200079B983 /* TrackService.swift in Sources */,
 				FDCC756729646D200079B983 /* AlbumService.swift in Sources */,
 				FDBE6BE72B559B20004F39CA /* appDatabase.swift in Sources */,

--- a/accentor/Api/AbstractService.swift
+++ b/accentor/Api/AbstractService.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import CoreData
+import OSLog
 
 enum ApiError: Error {
     case unauthorized
@@ -62,7 +63,7 @@ class AbstractService {
                 
                 guard (200...299).contains(response.statusCode) else {
                     // TODO: Be smarter about the possible status codes
-                    print("Error in API")
+                    Logger.api.info("API reponded with error code \(response.statusCode)")
                     switch response.statusCode {
                     case 401: throw ApiError.unauthorized
                     default: throw ApiError.unknown("Error in api \(response)")
@@ -99,7 +100,7 @@ class AbstractService {
 
         guard (200...299).contains(response.statusCode) else {
             // TODO: Be smarter about the possible status codes
-            print("Error in API")
+            Logger.api.info("API reponded with error code \(response.statusCode)")
             switch response.statusCode {
             case 401: throw ApiError.unauthorized
             default: throw ApiError.unknown("Error in api \(response)")

--- a/accentor/Api/AlbumService.swift
+++ b/accentor/Api/AlbumService.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import Sentry
+import OSLog
 
 struct AlbumService {
     static let apiPath = "albums"
@@ -28,7 +29,7 @@ struct AlbumService {
                     buffer.append(contentsOf: albums)
                     
                 } catch {
-                    print("Error decoding albums", error)
+                    Logger.api.error("Error decoding albums \(error)")
                 }
                 
                 count += 1
@@ -45,7 +46,7 @@ struct AlbumService {
             Task { try await AuthService(database).logout() }
         } catch {
             SentrySDK.capture(error: error)
-            print("Encountered an error fetching data", error)
+            Logger.api.error("Encountered an error fetching albums \(error)")
         }
     }
     
@@ -64,7 +65,7 @@ struct AlbumService {
             try await database.saveAlbums(albums: albums, albumArtists: albumArtists)
         } catch {
             SentrySDK.capture(error: error)
-            print(error)
+            Logger.api.error("Encountered an error saving albums \(error)")
         }
     }
 }

--- a/accentor/Api/ArtistService.swift
+++ b/accentor/Api/ArtistService.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import Sentry
+import OSLog
 
 struct ArtistService {
     static let apiPath = "artists"
@@ -28,7 +29,7 @@ struct ArtistService {
                     buffer.append(contentsOf: artists)
                     
                 } catch {
-                    print("Error decoding artists", error)
+                    Logger.api.error("Error decoding artists \(error)")
                 }
                 
                 count += 1
@@ -45,7 +46,7 @@ struct ArtistService {
             Task { try await AuthService(database).logout() }
         } catch {
             SentrySDK.capture(error: error)
-            print("Encountered an error fetching data", error)
+            Logger.api.error("Error fetching artists \(error)")
         }
     }
     
@@ -60,7 +61,7 @@ struct ArtistService {
             try await database.saveArtists(artists)
         } catch {
             SentrySDK.capture(error: error)
-            print(error)
+            Logger.api.error("Error saving artists \(error)")
         }
     }
 }

--- a/accentor/Api/AudioService.swift
+++ b/accentor/Api/AudioService.swift
@@ -29,7 +29,7 @@ class AudioService {
         
         
         downloadAudio(url: trackURL, toFile: fileCachePath, completion: { (error) in
-            print("Downlaoded audio from \(trackURL) and storing in \(fileCachePath)")
+            print("Downloaded audio from \(trackURL) and storing in \(fileCachePath)")
             completion(fileCachePath, error)
         })
     }

--- a/accentor/Api/AuthService.swift
+++ b/accentor/Api/AuthService.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import Sentry
+import OSLog
 
 struct APILoginBody: Codable {
     let name: String
@@ -48,19 +49,19 @@ struct AuthService {
             try await database.clearDatabase()
         } catch {
             SentrySDK.capture(error: error)
-            print(error)
+            Logger.api.error("Could not clear database \(error)")
         }
         
         let fileCachePath = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first!
         let files = try FileManager.default.contentsOfDirectory(at: fileCachePath, includingPropertiesForKeys: [])
-        print("Removing \(files.count) from audio cache")
+        Logger.api.info("Removing \(files.count) from audio cache")
         do {
             try files.forEach { path in
                 try FileManager.default.removeItem(atPath: path.path())
             }
         } catch {
             SentrySDK.capture(error: error)
-            print(error)
+            Logger.api.error("Could not remove track \(error)")
         }
     }
 }

--- a/accentor/Api/PlayService.swift
+++ b/accentor/Api/PlayService.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import Sentry
+import OSLog
 
 struct APIPlayBody: Codable {
     let trackId: Int64
@@ -36,7 +37,7 @@ struct PlayService {
                     buffer.append(contentsOf: plays)
                 } catch {
                     SentrySDK.capture(error: error)
-                    print("Error decoding plays", error)
+                    Logger.api.error("Error decoding plays \(error)")
                 }
                 
                 count += 1
@@ -53,7 +54,7 @@ struct PlayService {
             Task { try await AuthService(database).logout() }
         } catch {
             SentrySDK.capture(error: error)
-            print("Encountered an error fetching data", error)
+            Logger.api.error("Error fetching plays \(error)")
         }
     }
     
@@ -70,7 +71,7 @@ struct PlayService {
             Task { try await AuthService(AppDatabase.shared).logout() }
         } catch {
             SentrySDK.capture(error: error)
-            print("Encountered an error creating play", error)
+            Logger.api.error("Error creating play \(error)")
         }
         
     }

--- a/accentor/Api/TrackService.swift
+++ b/accentor/Api/TrackService.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import Sentry
+import OSLog
 
 struct TrackService {
     static let apiPath = "tracks";
@@ -28,7 +29,7 @@ struct TrackService {
                     buffer.append(contentsOf: tracks)
                 } catch {
                     SentrySDK.capture(error: error)
-                    print("Error decoding tracks", error)
+                    Logger.api.error("Error decoding tracks \(error)")
                 }
                 
                 count += 1
@@ -45,7 +46,7 @@ struct TrackService {
             Task { try await AuthService(AppDatabase.shared).logout() }
         } catch {
             SentrySDK.capture(error: error)
-            print("Encountered an error fetching data", error)
+            Logger.api.error("Error fetching tracks \(error)")
         }
     }
     
@@ -65,7 +66,7 @@ struct TrackService {
             try await database.saveTracks(tracks: tracks, trackArtists: trackArtists)
         } catch {
             SentrySDK.capture(error: error)
-            print(error)
+            Logger.api.error("Error storing tracks \(error)")
         }
     }
 }

--- a/accentor/Logger.swift
+++ b/accentor/Logger.swift
@@ -1,0 +1,16 @@
+//
+//  Logger.swift
+//  accentor
+//
+//  Created by Robbe Van Petegem on 03/08/2025.
+//
+
+import OSLog
+
+extension Logger {
+    private static var subsystem = Bundle.main.bundleIdentifier!
+    
+    static let api = Logger(subsystem: subsystem, category: "accentor.api")
+    
+    static let player = Logger(subsystem: subsystem, category: "accentor.player")
+}

--- a/accentor/Model/PlayQueue.swift
+++ b/accentor/Model/PlayQueue.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import CoreData
+import OSLog
 
 class PlayQueue: ObservableObject {
     enum QueueItemPosition: Equatable {
@@ -16,6 +17,7 @@ class PlayQueue: ObservableObject {
 
     @Published private(set) var queue: [PlayQueueItem] = []
     @Published private(set) var currentIndex: Int = -1
+    
     
     // PlayQueue is a singleton class, since we only ever want one queue in our whole app
     public static let shared = PlayQueue()
@@ -40,7 +42,6 @@ class PlayQueue: ObservableObject {
             currentIndex = -1
             return
         }
-        print("From `setIndex`", newIndex)
         currentIndex = newIndex
         
     }

--- a/accentor/Model/PlayQueueItem.swift
+++ b/accentor/Model/PlayQueueItem.swift
@@ -55,7 +55,7 @@ class PlayQueueItem {
 
 extension PlayQueueItem: CachingPlayerItemDelegate {
     func playerItem(_ playerItem: CachingPlayerItem, didFinishDownloadingData data: Data) {
-        print("finished downlaoding and storing in \(self.cachePath)")
+        print("finished downloading and storing in \(self.cachePath)")
         FileManager.default.createFile(atPath: self.cachePath, contents: data)
     }
 }

--- a/accentor/Player.swift
+++ b/accentor/Player.swift
@@ -12,6 +12,7 @@ import AVFoundation
 import MediaPlayer
 import GRDB
 import Sentry
+import OSLog
 
 class Player: ObservableObject {  // Possible values of `playerState`
     // The raw values match those of `MPNowPlayingPlaybackState`
@@ -126,7 +127,7 @@ extension Player {
         }
         catch {
             SentrySDK.capture(error: error)
-            print("Error while playing", error)
+            Logger.player.error("Error while playing \(error)")
         }
     }
     

--- a/accentor/Util/DefaultSettings.swift
+++ b/accentor/Util/DefaultSettings.swift
@@ -8,5 +8,9 @@
 import Foundation
 
 enum DefaultSettings {
+    #if DEBUG
+    static let codecConversionId = 1
+    #else
     static let codecConversionId = 3 // The MP3 320 codec in our current production ENV
+    #endif
 }

--- a/accentor/Util/DefaultSettings.swift
+++ b/accentor/Util/DefaultSettings.swift
@@ -8,9 +8,5 @@
 import Foundation
 
 enum DefaultSettings {
-    #if DEBUG
-    static let codecConversionId = 1
-    #else
     static let codecConversionId = 3 // The MP3 320 codec in our current production ENV
-    #endif
 }

--- a/accentor/appDatabase.swift
+++ b/accentor/appDatabase.swift
@@ -244,7 +244,7 @@ extension AppDatabase {
     func deleteOldAlbums(_ fetchedBefore: Date) async throws {
         try await dbWriter.write { db in
             let count = try Album.filter(Column("fetchedAt") < fetchedBefore).deleteAll(db)
-            print("Deleted \(count) old albums")
+            Logger.api.info("Deleted \(count) old albums")
         }
     }
     
@@ -259,7 +259,7 @@ extension AppDatabase {
     func deleteOldArtists(_ fetchedBefore: Date) async throws {
         try await dbWriter.write { db in
             let count = try Artist.filter(Column("fetchedAt") < fetchedBefore).deleteAll(db)
-            print("Deleted \(count) old artists")
+            Logger.api.info("Deleted \(count) old artists")
         }
     }
     
@@ -278,7 +278,7 @@ extension AppDatabase {
     func deleteOldTracks(_ fetchedBefore: Date) async throws {
         try await dbWriter.write { db in
             let count = try Track.filter(Column("fetchedAt") < fetchedBefore).deleteAll(db)
-            print("Deleted \(count) old tracks")
+            Logger.api.info("Deleted \(count) old tracks")
         }
     }
     
@@ -297,7 +297,7 @@ extension AppDatabase {
     func deleteOldPlays(_ fetchedBefore: Date) async throws {
         try await dbWriter.write { db in
             let count = try Play.filter(Column("fetchedAt") < fetchedBefore).deleteAll(db)
-            print("Deleted \(count) old plays")
+            Logger.api.info("Deleted \(count) old plays")
         }
     }
     


### PR DESCRIPTION
This switches a lot (but not all) of our print statements to use `OSLog` instead. This allows us to see these logs for release builds
